### PR TITLE
Provide same API as Asciidoctor core to trigger the template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Override asciidoctor.js html5 output with pug templates.
     // to the default backend behavior if there is no specific template for
     // that node.
 
-    asciidoctor.load("Hello world",
+    const doc = asciidoctor.load("Hello world",
                      { template_dirs: './path/to/template/directory' });
 
-    console.log(asciidoctor.convert());
+    console.log(doc.convert());
 
 
 The template directory should contain one template per type of node. The

--- a/README.md
+++ b/README.md
@@ -9,34 +9,39 @@ Override asciidoctor.js html5 output with pug templates.
 ## Installation
 
     npm install --save asciidoctor.js-pug
-    
+
 
 ## Usage
 
     // load asciidoctor.js
     const asciidoctor = require('asciidoctor.js')();
-    
-    // load asciidoctor.js-pug giving path to your pug template directory
-    require('asciidoctor.js-pug')('./path/to/template/directory');
-    
-    // At this point, the html5 backend has been patched to try first
-    // a pug template then to fallback to the usual behavior if not found
-    
-    // Use asciidoctor.js as usually
-    asciidoctor.load("Hello world");
+
+    // load asciidoctor.js-pug.
+    // This will register a new TemplateConverter with AsciiDoctor.
+    require('asciidoctor.js-pug');
+
+    // At this point, to convert a node, AsciiDoctor will try first to find
+    // a corresponding pug template in the directory passed in the
+    // `template_dirs` option. Then it will fallback
+    // to the default backend behavior if there is no specific template for
+    // that node.
+
+    asciidoctor.load("Hello world",
+                     { template_dirs: './path/to/template/directory' });
+
     console.log(asciidoctor.convert());
 
 
 The template directory should contain one template per type of node. The
 template name is made of the node_name + the `.pug` extension.
 
-See the test/templates folder for some examples/
+See the test/templates folder for some examples.
 
 ## Node version
 Require NodeJS >= v7.0
 Tested with v7.0, v7.6 and v8.9
- 
-## License 
+
+## License
 
 (The MIT License)
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -7,10 +7,34 @@ function hash_to_native($hash) {
   return $hash.$$smap;
 }
 
-const C = outils.subclass({
-  '$initialize': function(templates){
-    debug("$initialize", templates);
-    this.templates = templates;
+/**
+  Load all templates from a directory and store them in a map.
+*/
+function load_templates(template_dir) {
+  const glob = require('glob');
+  const path = require('path');
+  const pug = require('pug');
+
+  const templates = new Map();
+
+  // XXX it is unfortunate to use a synchronous method here...
+  for(let file of glob.sync(path.join(template_dir, "*.pug"))) {
+    debug("Load", file);
+    const key = path.parse(file).name;
+    const template = pug.compileFile(file);
+
+    templates.set(key, template);
+  }
+
+  return templates;
+}
+
+// XXX This is still a little bit verbose...
+const opal_module = outils.const_get_qualified('::Asciidoctor::Converter');
+const opal_base_converter = outils.const_get_qualified('::Asciidoctor::Converter::Base');
+const C = outils.subclass(opal_module, opal_base_converter, 'TemplateConverter', {
+  '$initialize': function(backend, template_dirs, opts){
+    this.templates = load_templates(template_dirs);
   },
 
   '$handles?': function(name){
@@ -42,4 +66,4 @@ const C = outils.subclass({
   },
 });
 
-module.exports = C;
+return C;

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,6 +1,5 @@
-if (typeof Opal === 'undefined') {
-  Opal = require('opal-runtime').Opal;
-}
+const debug = require('debug')('asciidoctor.js-pug:converter');
+const outils = require('../lib/opal-utils.js');
 
 
 // Some utilities
@@ -8,39 +7,39 @@ function hash_to_native($hash) {
   return $hash.$$smap;
 }
 
-const debug = require('debug')('asciidoctor.js-pug:converter');
+const C = outils.subclass({
+  '$initialize': function(templates){
+    debug("$initialize", templates);
+    this.templates = templates;
+  },
 
-C = Opal.Class.$new(Opal.Object /*, function(){} */);
-Opal.defn(C, '$initialize', function(templates){
-  this.templates = templates;
-});
+  '$handles?': function(name){
+    debug("handles?", name);
+    return this.templates.has(name);
+  },
 
-Opal.defn(C, '$handles?', function(name){
-  debug("handles?", name);
-  return this.templates.has(name);
-});
+  // XXX is this method really required?
+  '$converts?': function(name){
+    return true;
+  },
 
-// is this method really required?
-Opal.defn(C, '$converts?', function(backend){
-  return true;
-});
+  '$convert': function(node, template_name, opts){
+    template_name = template_name || node_name;
 
-Opal.defn(C, '$convert', function(node, template_name, opts){
-  template_name = template_name || node_name;
+    debug("convert", template_name);
+    //  console.log("convert", node);
 
-  debug("convert", template_name);
-//  console.log("convert", node);
+    // Provides a native JS node object to ease interface with pug
+    const native_node = Object.create(node);
+    native_node.content = () => node.$content();
+    native_node.image_uri = (target) => node.$image_uri(target);
+    native_node.attributes = node.attributes && hash_to_native(node.attributes);
 
-  // Provides a native JS node object to ease interface with pug
-  const native_node = Object.create(node);
-  native_node.content = () => node.$content();
-  native_node.image_uri = (target) => node.$image_uri(target);
-  native_node.attributes = node.attributes && hash_to_native(node.attributes);
-
-  return this.templates.get(template_name)({
-    node: native_node,
-    $node:node,
-  });
+    return this.templates.get(template_name)({
+      node: native_node,
+      $node:node,
+    });
+  },
 });
 
 module.exports = C;

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,6 @@ const PugConverter = require('./converter.js');
   // converted in a composite+template converter if
   // the 'template_dirs' argument is passed
   const inherited = outils.patch(Factory, '$create', function(backend, opts) {
-    debug("$create", backend, opts);
     const converter = inherited.call(this, backend, opts);
 
     if (opts.template_dirs) {
@@ -37,21 +36,4 @@ const PugConverter = require('./converter.js');
 
     return converter;
   });
-  debug("Patched", inherited);
 })();
-
-function load_templates(template_dir) {
-  const glob = require('glob');
-  const path = require('path');
-  const pug = require('pug');
-
-  const templates = new Map();
-  // XXX it is unfortunate to use a synchronous method here...
-  for(let file of glob.sync(path.join(template_dir, "*.pug"))) {
-    debug("Load", file);
-    const key = path.parse(file).name;
-    const template = pug.compileFile(file);
-
-    templates.set(key, template);
-  }
-}

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,22 +19,42 @@ var CompositeConverter = Opal.const_get_qualified(Converter, 'CompositeConverter
 // Load our converter
 const PugConverter = require('./converter.js');
 
-module.exports = function(template_dir) {
+(function(template_dir) {
+  const outils = require('./opal-utils.js');
+
+  // Patch the factory create method to wrap the standard
+  // converted in a composite+template converter if
+  // the 'template_dirs' argument is passed
+  const inherited = outils.patch(Factory, '$create', function(backend, opts) {
+    const converter = inherited.call(this, backend, opts);
+
+    if (opts.template_dirs) {
+      const templateConverter = PugConverter.$new(template_dirs);
+      converter = CompositeConverter.$new(backend, templateConverter, converter);
+    }
+
+    return converter;
+  });
+})();
+
   const debug = require('debug')('asciidoctor.js-pug:templates');
   const glob = require('glob');
   const path = require('path');
   const pug = require('pug');
-  
+
   const templates = new Map();
   // XXX it is unfortunate to use a synchronous method here...
   for(let file of glob.sync(path.join(template_dir, "*.pug"))) {
     debug("Load", file);
     const key = path.parse(file).name;
     const template = pug.compileFile(file);
-    
+
     templates.set(key, template);
   }
-  
+
+
+
+
   // Register globally as the new html5 converter:
   const opts = Opal.hash2([], {});
   const HTML5 = "html5";
@@ -43,4 +63,4 @@ module.exports = function(template_dir) {
       Html5Converter.$new(HTML5, opts)
     ), [HTML5]
   );
-}
+})();

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,8 @@
 if (typeof Opal === 'undefined') {
   Opal = require('opal-runtime').Opal;
 }
-
-var asciidoctor = require('asciidoctor.js')();
+const debug = require('debug')('asciidoctor.js-pug:templates');
+const asciidoctor = require('asciidoctor.js')();
 
 Opal.top.$require("asciidoctor/converter/html5");
 var Asciidoctor = Opal.const_get_qualified('::', 'Asciidoctor');
@@ -21,23 +21,26 @@ const PugConverter = require('./converter.js');
 
 (function(template_dir) {
   const outils = require('./opal-utils.js');
+  debug("Module start");
 
   // Patch the factory create method to wrap the standard
   // converted in a composite+template converter if
   // the 'template_dirs' argument is passed
   const inherited = outils.patch(Factory, '$create', function(backend, opts) {
+    debug("$create", backend, opts);
     const converter = inherited.call(this, backend, opts);
 
     if (opts.template_dirs) {
-      const templateConverter = PugConverter.$new(template_dirs);
+      const templateConverter = PugConverter.$new(load_templates(template_dirs));
       converter = CompositeConverter.$new(backend, templateConverter, converter);
     }
 
     return converter;
   });
+  debug("Patched", inherited);
 })();
 
-  const debug = require('debug')('asciidoctor.js-pug:templates');
+function load_templates(template_dir) {
   const glob = require('glob');
   const path = require('path');
   const pug = require('pug');
@@ -51,16 +54,4 @@ const PugConverter = require('./converter.js');
 
     templates.set(key, template);
   }
-
-
-
-
-  // Register globally as the new html5 converter:
-  const opts = Opal.hash2([], {});
-  const HTML5 = "html5";
-  Factory.$register(CompositeConverter.$new(HTML5,
-      PugConverter.$new(templates),
-      Html5Converter.$new(HTML5, opts)
-    ), [HTML5]
-  );
-})();
+}

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -49,17 +49,16 @@ function subclass(base, superclass, id, desc) {
   const C = (id) ? Opal.klass(base, superclass, id, function() {})
                  : Opal.Class.$new(superclass);
 
-  _inherited = {}; // the list of the original methods that where patched
+  const inherited = {}; // the list of the original methods that where patched
 
   debug("entries");
   for(let [key, value] of Object.entries(desc)) {
-    _inherited[key] = patch(C, key, value);
+    inherited[key] = patch(C, key, value);
   }
 
   debug("Done", !!C);
 
-  Opal.defn(C, '_inherited', _inherited);
-  Opal.defn(C, 'inherited', function(name) { return this._inherited[name].bind(this); });
+  Opal.defn(C, 'inherited', function(name) { return inherited[name].bind(this); });
   return C;
 }
 

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -1,0 +1,12 @@
+/*
+  The 'patch' methods allows to dynamically override a method
+  from an Opal object.
+
+  The replaced method is returned.
+*/
+module.exports.patch = function patch(klass, name, fn) {
+  const inherited = klass.$$proto[name];
+
+  Opal.defn(klass, name, fn);
+  return inherited;
+}

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -48,13 +48,11 @@ function subclass(base, superclass, id, desc) {
   const C = (id) ? Opal.klass(base, superclass, id, function() {})
                  : Opal.Class.$new(superclass);
 
-  const inherited = {}; // the list of the original methods that where patched
-
   for(let [key, value] of Object.entries(desc)) {
-    inherited[key] = patch(C, key, value);
+    patch(C, key, value);
   }
 
-  Opal.defn(C, 'inherited', function(name) { return inherited[name].bind(this); });
+  Opal.defn(C, 'inherited', function(base, name) { return base.$$proto[name].bind(this); });
   return C;
 }
 

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -49,16 +49,17 @@ function subclass(base, superclass, id, desc) {
   const C = (id) ? Opal.klass(base, superclass, id, function() {})
                  : Opal.Class.$new(superclass);
 
-  inherited = {}; // the list of the original methods that where patched
+  _inherited = {}; // the list of the original methods that where patched
 
   debug("entries");
   for(let [key, value] of Object.entries(desc)) {
-    inherited[key] = patch(C, key, value);
+    _inherited[key] = patch(C, key, value);
   }
 
   debug("Done", !!C);
 
-  Opal.defn(C, 'inherited', inherited);
+  Opal.defn(C, '_inherited', _inherited);
+  Opal.defn(C, 'inherited', function(name) { return this._inherited[name].bind(this); });
   return C;
 }
 

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -1,3 +1,5 @@
+const debug = require('debug')('asciidoctor.js-pug:opal-utils');
+
 /**
   The 'patch' methods allows to dynamically override a method
   from an Opal object.
@@ -15,21 +17,46 @@ function patch(klass, name, fn) {
 /**
   Subclass an Opal class from JavaScript.
 
-  If the base class is not provided, defaults to `Opal.Object`.
+  If the superclass class is not provided, defaults to `Opal.Object`.
+
+  Supports three signatures:
+  ```
+    // create a named class
+    subclass(module, superclass, 'name', { ... })
+
+    // Create an anonymous class
+    subclass(superclass, { ... })
+
+    // Create an anonymous class with Object as superclass
+    subclass({ ... })
+  ```
 */
 module.exports.subclass = subclass;
-function subclass(base, desc) {
+function subclass(base, superclass, id, desc) {
+  debug(1);
   if (arguments.length == 1) {
     desc = base;
-    base = Opal.Object;
+    superclass = Opal.Object;
+    base = id = undefined;
+  }
+  else if (arguments.length == 2) {
+    desc = superclass;
+    superclass = base;
+    base = id = null;
   }
 
-  const C = Opal.Class.$new(base);
+  debug("klass");
+  const C = (id) ? Opal.klass(base, superclass, id, function() {})
+                 : Opal.Class.$new(superclass);
+
   inherited = {}; // the list of the original methods that where patched
 
+  debug("entries");
   for(let [key, value] of Object.entries(desc)) {
     inherited[key] = patch(C, key, value);
   }
+
+  debug("Done", !!C);
 
   Opal.defn(C, 'inherited', inherited);
   return C;

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -45,18 +45,14 @@ function subclass(base, superclass, id, desc) {
     base = id = null;
   }
 
-  debug("klass");
   const C = (id) ? Opal.klass(base, superclass, id, function() {})
                  : Opal.Class.$new(superclass);
 
   const inherited = {}; // the list of the original methods that where patched
 
-  debug("entries");
   for(let [key, value] of Object.entries(desc)) {
     inherited[key] = patch(C, key, value);
   }
-
-  debug("Done", !!C);
 
   Opal.defn(C, 'inherited', function(name) { return inherited[name].bind(this); });
   return C;

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -1,4 +1,4 @@
-/*
+/**
   The 'patch' methods allows to dynamically override a method
   from an Opal object.
 
@@ -12,8 +12,18 @@ function patch(klass, name, fn) {
   return inherited;
 }
 
+/**
+  Subclass an Opal class from JavaScript.
+
+  If the base class is not provided, defaults to `Opal.Object`.
+*/
 module.exports.subclass = subclass;
 function subclass(base, desc) {
+  if (arguments.length == 1) {
+    desc = base;
+    base = Opal.Object;
+  }
+
   const C = Opal.Class.$new(base);
   inherited = {}; // the list of the original methods that where patched
 
@@ -23,4 +33,26 @@ function subclass(base, desc) {
 
   Opal.defn(C, 'inherited', inherited);
   return C;
+}
+
+module.exports.const_get_qualified = const_get_qualified;
+function const_get_qualified(base, path) {
+  if (arguments.length == 1) {
+    path = base;
+    base = '::';
+  }
+  const parts = path.split('::');
+  // special case of root anchored module -- ingore base in that case
+  if (parts[0] === '') {
+    parts.shift();
+    base = '::';
+  }
+
+  for(let part of parts) {
+    base = Opal.const_get_qualified(base, part, 'skip_raise');
+    if (!base)
+      break;
+  }
+
+  return base;
 }

--- a/lib/opal-utils.js
+++ b/lib/opal-utils.js
@@ -4,9 +4,23 @@
 
   The replaced method is returned.
 */
-module.exports.patch = function patch(klass, name, fn) {
+module.exports.patch = patch;
+function patch(klass, name, fn) {
   const inherited = klass.$$proto[name];
 
   Opal.defn(klass, name, fn);
   return inherited;
+}
+
+module.exports.subclass = subclass;
+function subclass(base, desc) {
+  const C = Opal.Class.$new(base);
+  inherited = {}; // the list of the original methods that where patched
+
+  for(let [key, value] of Object.entries(desc)) {
+    inherited[key] = patch(C, key, value);
+  }
+
+  Opal.defn(C, 'inherited', inherited);
+  return C;
 }

--- a/test/opal-utils.js
+++ b/test/opal-utils.js
@@ -215,7 +215,7 @@ describe("opal-utils", function() {
       const base = opalClass();
       const sub = outils.subclass(base, {
         '$m': function() {
-          return "overridden+" + this.inherited('$m')();
+          return "overridden+" + this.inherited(base, '$m')();
         },
       });
 
@@ -228,13 +228,30 @@ describe("opal-utils", function() {
       const sub = outils.subclass(base, {
         '$initialize': function() {
           this.derivedInitializeCalled = true;
-          this.inherited('$initialize')();
+          this.inherited(base, '$initialize')();
         },
       });
 
       const obj = sub.$new();
       assert.isTrue(obj.baseInitializeCalled);
       assert.isTrue(obj.derivedInitializeCalled);
+    });
+
+    it("should allow calling the inherited method [several levels of subclassing]", function() {
+      const base = opalClass();
+      const sub = outils.subclass(base, {
+        '$m': function() {
+          return "overridden+" + this.inherited(base, '$m')();
+        },
+      });
+      const sub2 = outils.subclass(sub, {
+        '$m': function() {
+          return "level3+" + this.inherited(sub, '$m')();
+        },
+      });
+
+      const obj = sub2.$new();
+      assert.equal(obj.$m(), "level3+overridden+original");
     });
 
     it("should share context beween JS calls", function() {

--- a/test/opal-utils.js
+++ b/test/opal-utils.js
@@ -157,6 +157,22 @@ describe("opal-utils", function() {
       const obj = sub.$new();
       assert.equal(obj.$m(), 'overridden+original');
     });
+
+    it("should share context beween JS calls", function() {
+      const base = opalClass();
+      const sub = outils.subclass(base, {
+        'set': function() {
+          this.value = 1;
+        },
+        'get': function() {
+          return this.value;
+        },
+      });
+
+      const obj = sub.$new();
+      obj.set();
+      assert.equal(obj.get(), 1);
+    });
   });
 
 });

--- a/test/opal-utils.js
+++ b/test/opal-utils.js
@@ -8,6 +8,11 @@ const assert = require('chai').assert;
 
 
 describe("opal-utils", function() {
+
+  /**
+    Create a new Opal class defining the $m and $self method for
+    testing purposes.
+  */
   const opalClass = function() {
     const C = Opal.Class.$new(Opal.Object /*, function(){} */);
     Opal.defn(C, '$m', function(){ return "original"; });
@@ -112,4 +117,46 @@ describe("opal-utils", function() {
     });
 
   });
+
+  describe("subclass", function() {
+    it("should create new Opal-like class", function() {
+      const base = opalClass();
+      const sub = outils.subclass(base, {});
+
+      const obj = sub.$new();
+      assert.equal(obj.$m(), "original");
+    });
+
+    it("should properly set the inheritance chain", function() {
+      const base = opalClass();
+      const sub = outils.subclass(base, {});
+
+      assert.equal(sub.$$parent, base);
+    });
+
+    it("should allow overriding Opal base-class methods", function() {
+      const base = opalClass();
+      const sub = outils.subclass(base, {
+        '$m': function() {
+          return "overridden";
+        },
+      });
+
+      const obj = sub.$new();
+      assert.equal(obj.$m(), 'overridden');
+    });
+
+    it("should allow calling the inherited method", function() {
+      const base = opalClass();
+      const sub = outils.subclass(base, {
+        '$m': function() {
+          return "overridden+" + this.inherited.$m();
+        },
+      });
+
+      const obj = sub.$new();
+      assert.equal(obj.$m(), 'overridden+original');
+    });
+  });
+
 });

--- a/test/opal-utils.js
+++ b/test/opal-utils.js
@@ -39,6 +39,44 @@ describe("opal-utils", function() {
 
   });
 
+  describe("const_get_qualified", function() {
+    const debug = require('debug')('asciidoctor.js-pug:opal-utils-modules');
+
+    require("asciidoctor.js")(); // Can't we avoid that depedency here?
+
+    it("should find a root module by absolute path", function() {
+      const module = outils.const_get_qualified("::Asciidoctor");
+      assert.equal(module.$$name, 'Asciidoctor');
+    });
+
+    it("should find a root module by relative path from root", function() {
+      const module = outils.const_get_qualified("::", "Asciidoctor");
+      assert.equal(module.$$name, 'Asciidoctor');
+    });
+
+    it("should find a nested module by absolute path", function() {
+      const module = outils.const_get_qualified("::Asciidoctor::Converter");
+      assert.equal(module.$$name, 'Converter');
+    });
+
+    it("should find a nested module by relative path", function() {
+      const base = outils.const_get_qualified("::", "Asciidoctor");
+      const module = outils.const_get_qualified(base, "Converter");
+      assert.equal(module.$$name, 'Converter');
+    });
+
+    it("should ignore base for absolute paths", function() {
+      const base = outils.const_get_qualified("::", "Asciidoctor");
+      const module = outils.const_get_qualified(base, "::Asciidoctor::Converter");
+      assert.equal(module.$$name, 'Converter');
+    });
+
+    it("should return `undefined` for missing module", function() {
+      const module = outils.const_get_qualified("::Asciidoctor::XYZ");
+      assert.isUndefined(module);
+    });
+  });
+
   describe("patch", function() {
     it("should replace existing methods", function() {
       const klass = opalClass();

--- a/test/opal-utils.js
+++ b/test/opal-utils.js
@@ -157,7 +157,7 @@ describe("opal-utils", function() {
   });
 
   describe("subclass", function() {
-    it("should create new Opal-like class", function() {
+    it("should create new anonymous Opal-like class", function() {
       const base = opalClass();
       const sub = outils.subclass(base, {});
 
@@ -165,11 +165,22 @@ describe("opal-utils", function() {
       assert.equal(obj.$m(), "original");
     });
 
+    it("should create new named Opal-like class", function() {
+      const base = opalClass();
+      const sub = outils.subclass(
+                    outils.const_get_qualified('::Asciidoctor'),
+                    base, 'XYZ', {});
+
+      const klass = outils.const_get_qualified('::Asciidoctor::XYZ')
+      const obj = klass.$new();
+      assert.equal(obj.$m(), "original");
+    });
+
     it("should properly set the inheritance chain", function() {
       const base = opalClass();
       const sub = outils.subclass(base, {});
 
-      assert.equal(sub.$$parent, base);
+      assert.isTrue(sub.$$parent === base); // strictEqual has issues with circular refs.
     });
 
     it("should allow overriding Opal base-class methods", function() {
@@ -182,6 +193,21 @@ describe("opal-utils", function() {
 
       const obj = sub.$new();
       assert.equal(obj.$m(), 'overridden');
+    });
+
+    it("should allow overriding base-class methods in named Opal-like class", function() {
+      const base = opalClass();
+      const sub = outils.subclass(
+                    outils.const_get_qualified('::Asciidoctor'),
+                    base, 'ABC', {
+                      '$m': function() {
+                        return "overridden";
+                      },
+                    });
+
+      const klass = outils.const_get_qualified('::Asciidoctor::ABC')
+      const obj = klass.$new();
+      assert.equal(obj.$m(), "overridden");
     });
 
     it("should allow calling the inherited method", function() {

--- a/test/opal-utils.js
+++ b/test/opal-utils.js
@@ -1,0 +1,115 @@
+if (typeof Opal === 'undefined') {
+  Opal = require('opal-runtime').Opal;
+}
+
+const outils = require('../lib/opal-utils.js');
+const debug = require('debug')('asciidoctor.js-pug:opal-utils');
+const assert = require('chai').assert;
+
+
+describe("opal-utils", function() {
+  const opalClass = function() {
+    const C = Opal.Class.$new(Opal.Object /*, function(){} */);
+    Opal.defn(C, '$m', function(){ return "original"; });
+    Opal.defn(C, '$self', function(){ return this; });
+
+    return C;
+  };
+
+  describe("opal runtime", function() {
+    //
+    // Test some assumptions I've made about the Opal runtime
+    //
+    it("should pass Opal object as this to JS methods", function() {
+      const klass = opalClass();
+      const obj = klass.$new();
+      assert.strictEqual(obj.$self(), obj);
+    });
+
+    it("should store methods in the $$proto class field", function() {
+      const klass = opalClass();
+      const obj = klass.$new();
+      assert.strictEqual(klass.$$proto.$m, obj.$m);
+    });
+
+  });
+
+  describe("patch", function() {
+    it("should replace existing methods", function() {
+      const klass = opalClass();
+      outils.patch(klass, "$m", function() {
+        return "patched";
+      });
+
+      const obj = klass.$new();
+      assert.equal(obj.$m(), "patched");
+    });
+
+    it("should be applied to exising objects", function() {
+      const klass = opalClass();
+      const obj = klass.$new(); // create object BEFORE patching the class
+
+      outils.patch(klass, "$m", function() {
+        return "patched";
+      });
+
+      assert.equal(obj.$m(), "patched");
+    });
+
+    it("should pass Opal object as this to *patched* JS methods", function() {
+      const klass = opalClass();
+      const obj = klass.$new(); // create object BEFORE patching the class
+
+      outils.patch(klass, "$self", function() {
+        return this;
+      });
+      assert.strictEqual(obj.$self(), obj);
+    });
+
+    it("should return the inherited method", function() {
+      /*
+        The idea is you have to use a closure to keep the original
+        method when you want to be able to call super():
+
+        ex.
+
+        const super = outils.patch(klass, "$m", function() {
+          ...
+          return super();
+        });
+       */
+      const klass = opalClass();
+      const obj = klass.$new(); // create object BEFORE patching the class
+      const original = obj['$m'];
+
+      const result = outils.patch(klass, "$m", function() {
+        return "patched";
+      });
+
+      assert.strictEqual(result, original);
+    });
+
+    it("should allow calling the inherited method", function() {
+      /*
+        The idea is you have to use a closure to keep the original
+        method when you want to be able to call super():
+
+        ex.
+
+        const super = outils.patch(klass, "$m", function() {
+          ...
+          return super();
+        });
+       */
+      const klass = opalClass();
+      const obj = klass.$new(); // create object BEFORE patching the class
+
+      const inherited = outils.patch(klass, "$m", function() {
+        return "patched+" + inherited.call(this); // XXX maybe should I bind() the result?
+      });
+
+      assert.equal(obj.$m(), "patched+original");
+    });
+
+  });
+});

--- a/test/opal-utils.js
+++ b/test/opal-utils.js
@@ -15,6 +15,7 @@ describe("opal-utils", function() {
   */
   const opalClass = function() {
     const C = Opal.Class.$new(Opal.Object /*, function(){} */);
+    Opal.defn(C, '$initialize', function(){ this.baseInitializeCalled = true; });
     Opal.defn(C, '$m', function(){ return "original"; });
     Opal.defn(C, '$self', function(){ return this; });
 
@@ -214,12 +215,26 @@ describe("opal-utils", function() {
       const base = opalClass();
       const sub = outils.subclass(base, {
         '$m': function() {
-          return "overridden+" + this.inherited.$m();
+          return "overridden+" + this.inherited('$m')();
         },
       });
 
       const obj = sub.$new();
-      assert.equal(obj.$m(), 'overridden+original');
+      assert.equal(obj.$m(), "overridden+original");
+    });
+
+    it("should allow calling the inherited constructor", function() {
+      const base = opalClass();
+      const sub = outils.subclass(base, {
+        '$initialize': function() {
+          this.derivedInitializeCalled = true;
+          this.inherited('$initialize')();
+        },
+      });
+
+      const obj = sub.$new();
+      assert.isTrue(obj.baseInitializeCalled);
+      assert.isTrue(obj.derivedInitializeCalled);
     });
 
     it("should share context beween JS calls", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -14,13 +14,13 @@ describe("asciidoctor", function() {
   });
 
   it("should convert simple texts", function() {
-    const doc = asciidoctor.loadFile('./test/data/001-plain-text.adoc');
+    const doc = asciidoctor.loadFile('./test/data/001-plain-text.adoc', {template_dirs: './test/templates'});
     const html = doc.convert({template_dirs: './test/templates'});
     debug(html);
   });
 
   it("should find templates for block elements", function() {
-    const doc = asciidoctor.loadFile('./test/data/002-blocks.adoc');
+    const doc = asciidoctor.loadFile('./test/data/002-blocks.adoc', {template_dirs: './test/templates'});
     const html = doc.convert({template_dirs: './test/templates'});
 
     debug(html);
@@ -28,7 +28,7 @@ describe("asciidoctor", function() {
   });
 
   it("should find href and anchor's target", function() {
-    const doc = asciidoctor.loadFile('./test/data/003-anchors.adoc');
+    const doc = asciidoctor.loadFile('./test/data/003-anchors.adoc', {template_dirs: './test/templates'});
     const html = doc.convert({template_dirs: './test/templates'});
     debug(html);
 
@@ -36,7 +36,7 @@ describe("asciidoctor", function() {
   });
 
   it("should access attributes", function() {
-    const doc = asciidoctor.loadFile('./test/data/004-attributes.adoc');
+    const doc = asciidoctor.loadFile('./test/data/004-attributes.adoc', {template_dirs: './test/templates'});
     const html = doc.convert({template_dirs: './test/templates'});
     debug(html);
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,8 +44,8 @@ describe("asciidoctor", function() {
   });
 
   it("should build proper image URI", function() {
-    const doc = asciidoctor.loadFile('./test/data/005-img-uri.adoc');
-    const html = doc.convert({template_dirs: './test/templates'});
+    const doc = asciidoctor.loadFile('./test/data/005-img-uri.adoc', {template_dirs: './test/templates'});
+    const html = doc.convert();
     debug(html);
 
     assert.include(html, '<IMG src="https://image.dir/source.png" alt="Atl Text Here"></IMG>');

--- a/test/test.js
+++ b/test/test.js
@@ -1,19 +1,27 @@
 const asciidoctor = require('asciidoctor.js')();
-require('../index.js')('./test/templates');
+require('../index.js');
 
 const debug = require('debug')('asciidoctor.js-pug:tests');
 const assert = require('chai').assert;
 
 describe("asciidoctor", function() {
-  it("should convert simple texts", function() {
+  it("bypass template engine if no template_dir", function() {
     const doc = asciidoctor.loadFile('./test/data/001-plain-text.adoc');
     const html = doc.convert();
+    assert.include(html, '</p>');
+    assert.notInclude(html, '</PARA>');
+    debug(html);
+  });
+
+  it("should convert simple texts", function() {
+    const doc = asciidoctor.loadFile('./test/data/001-plain-text.adoc');
+    const html = doc.convert({template_dirs: './test/templates'});
     debug(html);
   });
 
   it("should find templates for block elements", function() {
     const doc = asciidoctor.loadFile('./test/data/002-blocks.adoc');
-    const html = doc.convert();
+    const html = doc.convert({template_dirs: './test/templates'});
 
     debug(html);
     assert.include(html, '<PARA>');
@@ -21,25 +29,25 @@ describe("asciidoctor", function() {
 
   it("should find href and anchor's target", function() {
     const doc = asciidoctor.loadFile('./test/data/003-anchors.adoc');
-    const html = doc.convert();
+    const html = doc.convert({template_dirs: './test/templates'});
     debug(html);
-    
+
     assert.include(html, '<A HREF="http://asciidoctor.org">asciidoctor</A>');
   });
 
   it("should access attributes", function() {
     const doc = asciidoctor.loadFile('./test/data/004-attributes.adoc');
-    const html = doc.convert();
+    const html = doc.convert({template_dirs: './test/templates'});
     debug(html);
-    
+
     assert.include(html, '<IMG src="source.png" alt="Atl Text Here"></IMG>');
   });
 
   it("should build proper image URI", function() {
     const doc = asciidoctor.loadFile('./test/data/005-img-uri.adoc');
-    const html = doc.convert();
+    const html = doc.convert({template_dirs: './test/templates'});
     debug(html);
-    
+
     assert.include(html, '<IMG src="https://image.dir/source.png" alt="Atl Text Here"></IMG>');
   });
 });


### PR DESCRIPTION
Here is what I suggest so we may use the same API as Asciidoctor core: https://asciidoctor.org/docs/user-manual/#provide-custom-templates as explained in #1

(from the README file)
```
    // load asciidoctor.js
    const asciidoctor = require('asciidoctor.js')();

    // load asciidoctor.js-pug.
    // This will register a new TemplateConverter with AsciiDoctor.
    require('asciidoctor.js-pug');

    // At this point, to convert a node, AsciiDoctor will try first to find
    // a corresponding pug template in the directory passed in the
    // `template_dirs` option. Then it will fallback
    // to the default backend behavior if there is no specific template for
    // that node.

    const doc = asciidoctor.load("Hello world",
                     { template_dirs: './path/to/template/directory' });

    console.log(doc());
```

You will find a bunch of Mocha tests both for the template converter per se (./test/index.js) and for the low-level opal utilities I used (./test/opal-utils.js). All are passing on node.js. I have not tested on the other platforms.